### PR TITLE
Set jquery version required.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,5 +35,8 @@
     "bootstrap-treeview": "^1.2.0",
     "jquery-scrollto": "^1.4.6",
     "waypoints": "^4.0.1"
+    },
+  "resolutions": {
+    "jquery": "2.2.4"
   }
 }


### PR DESCRIPTION
Fixes #4 

More details at https://stackoverflow.com/questions/39513448/jquery-layout-throws-error-because-n-selector-is-undefined - .selector was deprecated in jquery 1.7 & removed in 3.